### PR TITLE
Rename the plugin: prettier -> ember-template-lint-plugin-prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const PrettierRule = class Prettier extends Rule {
 };
 
 module.exports = {
-  name: "prettier",
+  name: "ember-template-lint-plugin-prettier",
 
   rules: {
     prettier: PrettierRule
@@ -28,7 +28,7 @@ module.exports = {
   // Define configurations for this plugin that can be extended by the base configuration
   configurations: {
     recommended: {
-      plugins: ["prettier"],
+      plugins: ["ember-template-lint-plugin-prettier"],
       rules: {
         prettier: true
       }


### PR DESCRIPTION
To match package name. It seems that it's not already possible to use
the plugin's name to require it in `.template-lintrc.js` in
ember-template-lint plugin system. Instead, we currently need to require
it this way: `package-name/plugin-name`.