### PR TITLE
Take into account overrides key in .prettierrc.js

### DIFF
--- a/rules/lint-prettier.js
+++ b/rules/lint-prettier.js
@@ -33,7 +33,7 @@ module.exports = class Prettier extends Rule {
           }
 
           const source = this.sourceForNode(node);
-          const filepath = this.templateEnvironmentData.moduleName;
+          const filepath = this.templateEnvironmentData.moduleName + ".hbs";
 
           if (!prettier) {
             // Prettier is expensive to load, so only load it if needed.


### PR DESCRIPTION
Prettier needs the file extension to apply this kind of override:
```javascript
module.exports = {
  semi: true, // this will be applied to all files, javascript files for instance
  overrides: [
    {
      files: '**/*.hbs',
      options: {
        singleQuote: false, // this will be applied to hbs files only
      },
    },
  ],
};
```