### PR TITLE
Cleanup tests / CI / upgrade process for the two peerDependencies

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -9,3 +9,8 @@ update_configs:
       - match:
           update_type: "in_range"
     version_requirement_updates: "auto"
+    ignored_updates:
+      - match:
+          dependency_name: "prettier"
+      - match:
+          dependency_name: "ember-template-lint"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,21 @@ language: node_js
 node_js:
   - "8"
 
-sudo: false
-dist: trusty
-
-cache:
-  yarn: true
-
 branches:
   only:
     - master
     # npm version tags
     - /^v\d+\.\d+\.\d+/
+
+cache:
+  yarn: true
+
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+
+install:
+  - yarn install --frozen-lockfile --non-interactive
 
 env:
   global:
@@ -27,14 +31,8 @@ jobs:
     # runs linting and tests with current locked deps
 
     - stage: "Tests"
-      name: "Tests"
-      install:
-        - yarn install --non-interactive
+      name: "ember-template-lint 1.6.1"
       script:
         - yarn lint:js
         - yarn lint:md
         - yarn test
-
-before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
-  - export PATH=$HOME/.yarn/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,9 @@ jobs:
         - yarn lint:js
         - yarn lint:md
         - yarn test
+    - name: "ember-template-lint latest"
+      install: yarn install --no-lockfile
+      script:
+        - yarn lint:js
+        - yarn lint:md
+        - yarn test

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "Apache-2.0",
   "private": false,
   "peerDependencies": {
-    "ember-template-lint": "^1.3.0",
+    "ember-template-lint": "^1.6.1",
     "prettier": "^1.18.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,25 +18,25 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@glimmer/interfaces@^0.43.0":
-  version "0.43.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.43.0.tgz#a7a38c2476f87d68d6dc894840df17bc8b92de33"
-  integrity sha512-rWu6WHVo6tuFFOKOSJWAWsFfXZgkdnKDnvhl3tAb20njW/0uBZ2nx7GZ3lImvBeG0HoxyzYA7pD299ps03TemA==
+"@glimmer/interfaces@^0.42.2":
+  version "0.42.2"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.42.2.tgz#9cf8d6f8f5eee6bfcfa36919ca68ae716e1f78db"
+  integrity sha512-7LOuQd02cxxNNHChzdHMAU8/qOeQvTro141CU5tXITP7z6aOv2D2gkFdau97lLQiVxezGrh8J7h8GCuF7TEqtg==
 
-"@glimmer/syntax@^0.43.0":
-  version "0.43.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.43.0.tgz#d6e30c857c575eeac25b3f7ffab2cfee43685726"
-  integrity sha512-qJqzcbF9lgdLE5A1rCwTs0CLnblNK95Y6MMLNsvJEJA7j1Gx50ySoUZ5HTk86Z5auhDgvInhuufyGtdojSIMSg==
+"@glimmer/syntax@^0.42.2":
+  version "0.42.2"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.42.2.tgz#89bb3cb787285b84665dc0d8907d94b008e5be9a"
+  integrity sha512-SR26SmF/Mb5o2cc4eLHpOyoX5kwwXP4KRhq4fbWfrvan74xVWA38PLspPCzwGhyVH/JsE7tUEPMjSo2DcJge/Q==
   dependencies:
-    "@glimmer/interfaces" "^0.43.0"
-    "@glimmer/util" "^0.43.0"
+    "@glimmer/interfaces" "^0.42.2"
+    "@glimmer/util" "^0.42.2"
     handlebars "^4.0.13"
     simple-html-tokenizer "^0.5.8"
 
-"@glimmer/util@^0.43.0":
-  version "0.43.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.43.0.tgz#dd28cd1a233c25427032437b9050c6fa6d098e2c"
-  integrity sha512-RtjHU8/rhysOugu+Q0j6dQ3G67J4h45tQgKPEwVPxu8P+hqijqnz/lBLxTdVg/1zKmlqUkyngTr8H4Jpg2yF/g==
+"@glimmer/util@^0.42.2":
+  version "0.42.2"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.42.2.tgz#9ca1631e42766ea6059f4b49d0bdfb6095aad2c4"
+  integrity sha512-Heck0baFSaWDanCYtmOcLeaz7v+rSqI8ovS7twrp2/FWEteb3Ze5sWQ2BEuSAG23L/k/lzVwYM/MY7ZugxBpaA==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -625,11 +625,11 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     stream-shift "^1.0.0"
 
 ember-template-lint@^1.6.1:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/ember-template-lint/-/ember-template-lint-1.7.0.tgz#aa08dd9cb5b687209bfa27b4fe8605545c1184f5"
-  integrity sha512-BXXofuXOATt6Tz3wfsQK1iw3DLKgDTgeNOJeP6jH+Jxqpz7c84BLgISeLDdDsBfYumUeUQORDrmwI9Ia69iOGw==
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/ember-template-lint/-/ember-template-lint-1.6.1.tgz#9530f702996691d479570be71cab396d42b07234"
+  integrity sha512-vETWXQtQzv+hZc0/vOrox0+6G+5Sr0qPEOnaTy0ZkwcRv9TJyflru7IXm3V1vEtKCljR7pHzRQ4/IsSEWSDLVw==
   dependencies:
-    "@glimmer/syntax" "^0.43.0"
+    "@glimmer/syntax" "^0.42.2"
     chalk "^2.0.0"
     globby "^9.0.0"
     minimatch "^3.0.4"


### PR DESCRIPTION
### testing in CI
- add a CI job to test against the two peerDependencies latest versions (by ignoring the lockfile)
- test against the lowest supported peerDependencies versions in the existing CI job

### dependencies
- use the peerDependencies' versions in the devDependencies to be able to test against the two above-mentioned scenario
- bump `ember-template-lint` peerDependency from 1.3.0 to 1.6.1 because we can't test 1.3.0 anymore (see https://github.com/dcyriller/ember-template-lint-plugin-prettier/pull/41)
- configure dependabot to upgrade `prettier` and `ember-template-lint` manually

### cleanup
- cleanup the travis file